### PR TITLE
Add missing TreeView support for selections in ImportExport config.

### DIFF
--- a/Kernel/Output/HTML/ImportExportLayoutSelection.pm
+++ b/Kernel/Output/HTML/ImportExportLayoutSelection.pm
@@ -90,6 +90,7 @@ sub FormInputCreate {
         Data         => $Param{Item}->{Input}->{Data} || {},
         SelectedID   => $Param{Value},
         Translation  => $Param{Item}->{Input}->{Translation},
+        TreeView     => $Param{Item}->{Input}->{TreeView} || 0,
         PossibleNone => $Param{Item}->{Input}->{PossibleNone},
         Multiple     => $Param{Item}->{Input}->{Multiple},
         Size         => $Param{Item}->{Input}->{Size},


### PR DESCRIPTION
When configuring ImportExport definitions, it is now possible to use
`TreeView` representations of selections.